### PR TITLE
Added support for externally hosted images on http websites

### DIFF
--- a/TechNet-Gallery-to-GitHub-Migrator.ps1
+++ b/TechNet-Gallery-to-GitHub-Migrator.ps1
@@ -245,7 +245,7 @@ foreach($TechNetURL in $TechNetURLs)
 	foreach($image in $imageArray)
 	{
 		$imageFile = $image.Groups[1].Value
-		if(!($imageFile -imatch "^https:"))
+		if(!($imageFile -imatch "^https:" -or $imageFile -imatch "^http:"))
 		{
 			Write-Host "INFO: Incomplete URL: $imageFile" -foreground "yellow"
 			Write-Host "INFO: Incomplete URL add https://gallery.technet.microsoft.com" -foreground "yellow"


### PR DESCRIPTION
Change to stop script incorrectly prepending "https://gallery.technet.microsoft.com" if an image is hosted on an external http based website.

